### PR TITLE
docs: simplify workflow-templates descriptions

### DIFF
--- a/workflow-templates/npm-publish.properties.json
+++ b/workflow-templates/npm-publish.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "Publish Node.js Package",
-    "description": "Use this workflow to publish your package to NPM",
+    "description": "Publish your package to NPM",
     "iconName": "edx-workflow-template-icon",
     "categories": [
         "javascript"

--- a/workflow-templates/pypi-publish.properties.json
+++ b/workflow-templates/pypi-publish.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "Publish Python Package",
-    "description": "Use this workflow to publish your package to PyPI",
+    "description": "Publish your package to PyPI",
     "iconName": "edx-workflow-template-icon",
     "categories": [
         "python"

--- a/workflow-templates/upgrade-python-requirements.properties.json
+++ b/workflow-templates/upgrade-python-requirements.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "Python Requirements Upgrade Workflow",
-    "description": "Use this workflow to regularly run `make upgrade` to keep your python requirements up to date",
+    "description": "Regularly run `make upgrade` to keep your python requirements up to date",
     "iconName": "edx-workflow-template-icon",
     "categories": [
         "python"


### PR DESCRIPTION
to remove the boilerplate/superfluous text:

> Use this workflow to ...

This makes it easier to parse the list of organizational workflows
and is in following the convention used by Github's "popular services".

> Publish ...
> Build and test ...
> Setup ...