### PR TITLE
build: add a commitlint workflow template

### DIFF
--- a/workflow-templates/commitlint.properties.json
+++ b/workflow-templates/commitlint.properties.json
@@ -1,0 +1,7 @@
+{
+    "name": "Commitlint Workflow",
+    "description": "Run commitlint on the commits in a pull request",
+    "iconName": "edx-workflow-template-icon",
+    "categories": [],
+    "filePatterns": []
+}

--- a/workflow-templates/commitlint.yml
+++ b/workflow-templates/commitlint.yml
@@ -1,0 +1,37 @@
+# Run commitlint on the commit messasges in a pull request.
+
+name: Lint Commit Messages
+
+on:
+  - pull_request
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Check for a local configuration file
+        id: check
+        run: |
+          if [[ ! -f commitlint.config.js ]]; then
+            echo "::set-output name=need::yes"
+          fi
+
+      - name: Download configuration if needed
+        if: steps.check.outputs.need == 'yes'
+        uses: wei/wget@v1
+        with:
+          args: -O commitlint.config.js https://raw.githubusercontent.com/edx/edx-lint/HEAD/edx_lint/files/commitlint.config.js
+
+      - name: Run commitlint
+        uses: wagoid/commitlint-github-action@v4
+        with:
+          helpURL: https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html


### PR DESCRIPTION
This workflow will run commitlint on the commits in a pull request, to see that they conform to OEP-51.  The repo doesn't need to have a configuration file; it will be downloaded from the edx-lint repo.  However, a local configuration file will be used if present.