### PR TITLE
feat: Added workflow for lockfileVersion check

### DIFF
--- a/.github/workflows/lockfileversion-check.yml
+++ b/.github/workflows/lockfileversion-check.yml
@@ -1,0 +1,26 @@
+#check package-lock file version
+
+name: lockfileVersion check
+
+on:
+  - workflow_call
+
+jobs:
+  version-check:
+    runs-on:  ubuntu-20.04
+    outputs:
+      output1: ${{ steps.getversion.outputs.version }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Retrieve version
+      id: getversion
+      run: |
+        echo "::set-output name=version::$(cat package-lock.json | grep '\"lockfileVersion\": 2,')"
+
+    - name: check value
+      if: ${{ steps.getversion.outputs.version == null }}
+      run: |
+        echo "ERROR: Outdated package-lock file. Use NPM8 to install dependencies "
+        exit 1

--- a/workflow-templates/lockfileversion-check.yml
+++ b/workflow-templates/lockfileversion-check.yml
@@ -1,0 +1,13 @@
+#check package-lock file version
+
+name: lockfileVersion check
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  version-check:
+    uses: edx/.github/.github/workflows/lockfileversion-check.yml@master

--- a/workflow-templates/lockfileversion.properties.json
+++ b/workflow-templates/lockfileversion.properties.json
@@ -1,0 +1,7 @@
+{
+    "name": "LockfileVersion Workflow",
+    "description": "Verify lockfileVersion is 2 in package-lock.json",
+    "iconName": "edx-workflow-template-icon",
+    "categories": [],
+    "filePatterns": []
+}


### PR DESCRIPTION
`lockfileVersion` value for the package-lock.json generated by NPM6 is **1** but now as we've moved to Node16 and NPM8, package-lock.json should be generated using NPM8. `lockfileVersion `for package-lock.json generated using NPM8 is **2**. So here we're going to check the lockfileVersion in package-lock.json in order to verify that dependencies were installed using NPM8.