### PR TITLE
fix: update commitlint config url

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -32,7 +32,7 @@ jobs:
         if: steps.check.outputs.need == 'yes'
         uses: wei/wget@v1
         with:
-          args: -O commitlint.config.js https://raw.githubusercontent.com/edx/edx-lint/HEAD/edx_lint/files/commitlint.config.js
+          args: -O commitlint.config.js https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/commitlint.config.js
 
       - name: Run commitlint
         uses: wagoid/commitlint-github-action@v4


### PR DESCRIPTION
## Description

- seems that HEAD vs master behavior has changed for raw content urls
- @nedbat  is checking in with github