### PR TITLE
build: Install node 16 in bulk repo update job

### DIFF
--- a/.github/workflows/bulk_repo_update.yml
+++ b/.github/workflows/bulk_repo_update.yml
@@ -92,6 +92,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ github.event.inputs.python_version }}
+          
+      - name: Setup Nodejs
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
 
       - name: install packages
         if: ${{ github.event.inputs.packages }}


### PR DESCRIPTION
We have upgrade Node to v16 so we had previously created a [PR](https://github.com/edx/jenkins-job-dsl/pull/1505) to install Node 16 in Jenkins worker but as we have moved to GitHub Actions, creating a PR to setup Node 16 in bulk repo update job's environment here.