### PR TITLE
Add token to repo checkout

### DIFF
--- a/.github/workflows/bulk_repo_update.yml
+++ b/.github/workflows/bulk_repo_update.yml
@@ -1,7 +1,7 @@
 name: Bulk Repo Update
 
 # This workflow is used to run a script on a list of repos and create PRs for the changes introduced by script.
-# Note that this workflow won't work on private repos and those repos where active branch isn't master.
+# Note that this workflow won't work on repos where active branch isn't master.
 # A new input for active branch can be added if Github allows more than 10 inputs in future.
 
 on:

--- a/.github/workflows/bulk_repo_update.yml
+++ b/.github/workflows/bulk_repo_update.yml
@@ -87,6 +87,7 @@ jobs:
         with:
             repository: ${{ github.event.inputs.organization}}/${{ matrix.repos }}
             ref: 'master'
+            token: ${{ secrets.requirements_bot_github_token }}
 
       - name: setup python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Previously the bulk repo update job would fail for private repos. This PR adds `token` to `checkout` action which gives access to private repos and hence makes the job work for both public and private repos