### PR TITLE
Fix repo checkout for bulk repo job

### DIFF
--- a/.github/workflows/bulk_repo_update.yml
+++ b/.github/workflows/bulk_repo_update.yml
@@ -83,10 +83,9 @@ jobs:
         repos: ${{fromJson(needs.repos_list.outputs.output1)}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
             repository: ${{ github.event.inputs.organization}}/${{ matrix.repos }}
-            ref: 'master'
             token: ${{ secrets.requirements_bot_github_token }}
 
       - name: setup python


### PR DESCRIPTION
The bulk repo job fails for repos that have default branch other than `master`. We can't currently provide another parameter to the job as there is a limit of 10 inputs and we already have 10 inputs for the job defined. Removing the ref input from the repo checkout should resolve our issue because the checkout action should checkout to the default branch of the repo whether it is master or main.

Link to the error: https://github.com/edx/.github/actions/runs/3827949582/jobs/6513005282
Link to the actions checkout description: https://github.com/actions/checkout#usage