### PR TITLE
Use checked out branch as target branch

### DIFF
--- a/.github/workflows/bulk_repo_update.yml
+++ b/.github/workflows/bulk_repo_update.yml
@@ -97,6 +97,10 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16
+          
+      - name: Set Checked out Branch name
+        id: branch-name
+        run: echo "BRANCH=${{ github.head_ref || github.ref_name }}" >> $GITHUB_OUTPUT
 
       - name: install packages
         if: ${{ github.event.inputs.packages }}
@@ -127,7 +131,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/testeng-ci
           python -m jenkins.pull_request_creator --repo-root=$GITHUB_WORKSPACE \
-          --target-branch="master" --base-branch-name="${{ github.event.inputs.branch }}" \
+          --target-branch="${{ steps.branch-name.outputs.BRANCH }}" --base-branch-name="${{ github.event.inputs.branch }}" \
           --commit-message="${{ github.event.inputs.commit_message }}" \
           --pr-title="${{ github.event.inputs.commit_message }}"  \
           --pr-body="${{ github.event.inputs.pr_body }}"  --user-reviewers=${{ github.actor }} \


### PR DESCRIPTION
Master branch is mentioned as the target branch for pull request creator but it is not the case for every repo. Some repos have main branch as their default branch and hence we need to set that as target branch. This PR fixes this issue