### PR TITLE
chore: update to ubuntu-latest

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   commitlint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
ubuntu 20.04 is deprecated and will be removed by 2025-04-01