### PR TITLE
build: use ubuntu-latest to run workflow

### DIFF
--- a/.github/workflows/bulk_repo_update.yml
+++ b/.github/workflows/bulk_repo_update.yml
@@ -63,7 +63,7 @@ on:
 jobs:
 
   repos_list:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     outputs:
       output1: ${{ steps.repos_list.outputs.list }}
@@ -75,7 +75,7 @@ jobs:
         echo "list=[${{github.event.inputs.repos_list}}]" >> $GITHUB_OUTPUT
 
   bulk_update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [ repos_list ]
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description
- Using `ubuntu-20.04` as the OS for github runners has been [deprecated](https://github.com/actions/runner-images/issues/11101) since 1st April, 2025 which is causing the `bulk-repo-update` job build to get stuck when waiting for the runner even though the runners are available for the repository. 
- Updating `os: ubuntu-latest` to fix this issue for now and always use the latest version avoid this issue in the future.